### PR TITLE
Direct hit display in detail pages

### DIFF
--- a/app/name/[name]/DirectHitAccordion.tsx
+++ b/app/name/[name]/DirectHitAccordion.tsx
@@ -2,8 +2,8 @@
 
 import { useMemo } from 'react';
 import Link from 'next/link';
+import { Link as NextUILink } from '@nextui-org/link';
 import { Accordion, AccordionItem } from '@nextui-org/accordion';
-import { Chip } from '@nextui-org/chip';
 
 type Props = {
   /** Scam site report with direct hit */
@@ -50,17 +50,22 @@ export default function DirectHitAccordion({ directHits }: Props) {
           title={host}
           subtitle={`${records[records.length - 1].startDate} ~ ${records[0].endDate} 共通報 ${records.reduce((sum, { count }) => sum + count, 0)} 次`}
         >
-          <Link href={`/host/${host}`}>查詢 {host} 的詐騙紀錄</Link>
-          警政署公告
+          <Link href={`/host/${host}`} passHref legacyBehavior>
+            <NextUILink>查詢 {host} 的詐騙紀錄與類似網域</NextUILink>
+          </Link>
+          <h2 className="mt-2">
+            警政署針對 {records[0].name} - {host} 的公告
+          </h2>
           <ul>
             {records.map((record) => (
               <li key={record.id}>
-                <Link
+                <NextUILink
+                  isExternal
+                  showAnchorIcon
                   href={`https://165.npa.gov.tw/#/article/9/${record.announcementId}#:~:text=${record.name}`}
                 >
-                  {record.announcementTitle}
-                </Link>{' '}
-                （通報 {record.count} 件）
+                  {record.announcementTitle}（通報 {record.count} 件）
+                </NextUILink>{' '}
               </li>
             ))}
           </ul>

--- a/app/name/[name]/DirectHitAccordion.tsx
+++ b/app/name/[name]/DirectHitAccordion.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { Accordion, AccordionItem } from '@nextui-org/accordion';
+import { Chip } from '@nextui-org/chip';
+
+type Props = {
+  /** Scam site report with direct hit */
+  directHits: {
+    id: number;
+    name: string;
+    count: number;
+    startDate: string;
+    endDate: string;
+    host: string;
+    announcementId: number;
+    announcementTitle: string;
+  }[];
+};
+
+export default function DirectHitAccordion({ directHits }: Props) {
+  // directHits are already sorted by endDate desc.
+  // We group them by host, latest endDate first.
+  const directHitsByHosts = useMemo(
+    () =>
+      directHits.reduce((acc, record) => {
+        const host = record.host;
+        const recordsOfHost = acc.get(host);
+        if (recordsOfHost) {
+          recordsOfHost.push(record);
+        } else {
+          acc.set(host, [record]);
+        }
+        return acc;
+      }, new Map<string, Props['directHits']>()),
+    [directHits]
+  );
+
+  return (
+    <Accordion
+      variant="bordered"
+      selectionMode="multiple"
+      // Open first host by default
+      defaultExpandedKeys={[directHits[0].host]}
+    >
+      {Array.from(directHitsByHosts.entries()).map(([host, records]) => (
+        <AccordionItem
+          key={host}
+          title={host}
+          subtitle={`${records[records.length - 1].startDate} ~ ${records[0].endDate} 共通報 ${records.reduce((sum, { count }) => sum + count, 0)} 次`}
+        >
+          <Link href={`/host/${host}`}>查詢 {host} 的詐騙紀錄</Link>
+          警政署公告
+          <ul>
+            {records.map((record) => (
+              <li key={record.id}>
+                <Link
+                  href={`https://165.npa.gov.tw/#/article/9/${record.announcementId}#:~:text=${record.name}`}
+                >
+                  {record.announcementTitle}
+                </Link>{' '}
+                （通報 {record.count} 件）
+              </li>
+            ))}
+          </ul>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}

--- a/app/name/[name]/page.tsx
+++ b/app/name/[name]/page.tsx
@@ -38,6 +38,7 @@ export default async function ReportByName({
                 <th>Count</th>
                 <th>Start Date</th>
                 <th>End Date</th>
+                <th>165</th>
               </tr>
             </thead>
             <tbody>
@@ -50,6 +51,13 @@ export default async function ReportByName({
                   <td>{record.count}</td>
                   <td>{record.startDate}</td>
                   <td>{record.endDate}</td>
+                  <td>
+                    <Link
+                      href={`https://165.npa.gov.tw/#/article/9/${record.announcementId}#:~:text=${record.name}`}
+                    >
+                      {record.announcementTitle}
+                    </Link>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/app/name/[name]/page.tsx
+++ b/app/name/[name]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Highlighted from '@/components/Highlighted';
+import DirectHitAccordion from './DirectHitAccordion';
 import { getRecords } from '@/app/name/util';
 import { Paragraph } from '@/components/contents';
 
@@ -30,38 +31,8 @@ export default async function ReportByName({
             以下是內政部警政署 165 的開放資料所公布，使用「{name}
             」名義的詐騙網站，以及收到回報的次數。
           </Paragraph>
-          <table>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>URL</th>
-                <th>Count</th>
-                <th>Start Date</th>
-                <th>End Date</th>
-                <th>165</th>
-              </tr>
-            </thead>
-            <tbody>
-              {directHits.map((record) => (
-                <tr key={record.id}>
-                  <td>{record.name}</td>
-                  <td>
-                    <Link href={`/host/${record.host}`}>{record.url}</Link>
-                  </td>
-                  <td>{record.count}</td>
-                  <td>{record.startDate}</td>
-                  <td>{record.endDate}</td>
-                  <td>
-                    <Link
-                      href={`https://165.npa.gov.tw/#/article/9/${record.announcementId}#:~:text=${record.name}`}
-                    >
-                      {record.announcementTitle}
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+
+          <DirectHitAccordion directHits={directHits} />
         </>
       )}
 

--- a/app/name/util.tsx
+++ b/app/name/util.tsx
@@ -11,6 +11,8 @@ type Record = {
   startDate: string;
   endDate: string;
   host: string;
+  announcementId: number;
+  announcementTitle: string;
 };
 
 /** Get records with site name */
@@ -19,8 +21,12 @@ export const getRecords = cache(async (name: string) => {
   const directHitPromise = db
     .prepare(
       `
-        SELECT *
+        SELECT
+          ScamSiteRecord.*,
+          ScamSiteAnnouncement.id AS announcementId,
+          ScamSiteAnnouncement.title AS announcementTitle
         FROM ScamSiteRecord
+        LEFT JOIN ScamSiteAnnouncement ON ScamSiteRecord.endDate = ScamSiteAnnouncement.endDate
         WHERE lower(name) = lower(?)
         ORDER BY endDate DESC
       `

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@cloudflare/next-on-pages": "^1.12.1",
         "@cloudflare/workers-types": "^4.20240712.0",
+        "@total-typescript/ts-reset": "^0.6.1",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -4519,6 +4520,12 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@total-typescript/ts-reset": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@total-typescript/ts-reset/-/ts-reset-0.6.1.tgz",
+      "integrity": "sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==",
+      "dev": true
     },
     "node_modules/@ts-morph/common": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.12.1",
     "@cloudflare/workers-types": "^4.20240712.0",
+    "@total-typescript/ts-reset": "^0.6.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/reset.d.ts
+++ b/reset.d.ts
@@ -1,0 +1,1 @@
+import '@total-typescript/ts-reset';

--- a/scripts/genSchema.ts
+++ b/scripts/genSchema.ts
@@ -4,8 +4,31 @@
 
 import { readFileSync, writeFileSync } from 'fs';
 
-const input = JSON.parse(readFileSync(0, 'utf-8'))[0]
-  .results.map((row: { sql: string }) => row.sql)
+/**
+ * The JSON result of `SELECT sql FROM sqlite_master`.
+ * @example [
+ *   {
+ *     "results": [
+ *       {
+ *         "sql": "CREATE TABLE _cf_KV (\n      key TEXT PRIMARY KEY,\n      value BLOB\n    ) WITHOUT ROWID"
+ *       },
+ *       {
+ *         "sql": "CREATE TABLE d1_migrations(\n\t\tid         INTEGER PRIMARY KEY AUTOINCREMENT,\n\t\tname       TEXT UNIQUE,\n\t\tapplied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL\n)"
+ *       },
+ *       {
+ *         "sql": "null"
+ *       },
+ *       {
+ *         "sql": "CREATE TABLE sqlite_sequence(name,seq)"
+ *       }, // ......
+ *     ]
+ *   }
+ * ]
+ **/
+type SQLResults = { results: { sql: string }[] }[];
+
+const input = (JSON.parse(readFileSync(0, 'utf-8')) as SQLResults)[0].results
+  .map((row: { sql: string }) => row.sql)
   .filter((sql: string) => sql !== 'null') // sqlite_autoindex_d1_migrations_1 has SQL being string "null"
   .join('\n\n');
 


### PR DESCRIPTION
- Implements direct hit accordion and load data from DB for scam site names
- Refactor: add ts-reset for more straightforward built-in types
    - Need to fix type for script

---
- Figma: https://www.figma.com/design/Fqcv6KODgXFWyyjj1Ru9er/Open165?node-id=2001-1636&t=dWPf3fxWw8EtP5Z8-4
- Preview: https://detail-hit.site-9hb.pages.dev/name/%E4%B8%8A%E6%B5%B7%E6%9C%9F%E8%B2%A8%E4%BA%A4%E6%98%93%E6%89%80

![圖片](https://github.com/user-attachments/assets/79ae8be2-be0f-4558-b9c5-2ee75210a866)
