### PR TITLE
Name detail page summary and refactor

### DIFF
--- a/app/name/[name]/layout.tsx
+++ b/app/name/[name]/layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-// import { getRecords } from '@/app/name/util';
+import { getRecords, getSummary } from '@/app/name/util';
 import ScamTabs from '@/components/ScamTabs';
+import { Heading, Paragraph } from '@/components/contents';
 
 export const runtime = 'edge';
 
@@ -11,11 +12,12 @@ export default async function Name({
   children,
 }: React.PropsWithChildren<Props>) {
   const name = decodeURIComponent(encodedName).trim();
-  // const [directHits, ftsHits] = await getRecords(name);
+  const [directHits] = await getRecords(name);
 
   return (
     <main>
-      <h1 className="font-serif font-light text-6xl">{name}</h1>
+      <Heading>{name}</Heading>
+      <Paragraph>{getSummary(name, directHits)}</Paragraph>
       <ScamTabs name={name} basePath={`/name/${encodedName}`} />
       {children}
     </main>

--- a/app/name/[name]/mitigation/page.tsx
+++ b/app/name/[name]/mitigation/page.tsx
@@ -1,3 +1,4 @@
+import { Paragraph } from '@/components/contents';
 import Mitigation from '@/components/Mitigation';
 
 type Props = { params: { name: string } };
@@ -9,7 +10,7 @@ export default function MitigationByName({
 
   return (
     <>
-      <p>詐騙集團用 {name} 的名義騙了你嗎？請參考以下建議。</p>
+      <Paragraph>詐騙集團用 {name} 的名義騙了你嗎？請參考以下建議。</Paragraph>
       <Mitigation />
     </>
   );

--- a/app/name/[name]/page.tsx
+++ b/app/name/[name]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import Highlighted from '@/components/Highlighted';
 import { getRecords } from '@/app/name/util';
+import { Paragraph } from '@/components/contents';
 
 type Props = { params: { name: string } };
 
@@ -10,13 +11,25 @@ export default async function ReportByName({
   const name = decodeURIComponent(encodedName).trim();
   const [directHits, ftsHits] = await getRecords(name);
 
+  if (directHits.length === 0 && ftsHits.length === 0) {
+    return (
+      <>
+        <Paragraph>查無名為「{name}」的詐騙網站。</Paragraph>
+      </>
+    );
+  }
+
   return (
     <>
-      {directHits.length === 0 ? (
-        `The name ${name} is not reported by 165 yet.`
-      ) : (
+      {directHits.length > 0 && (
         <>
-          The name “{name}” is used by the following know scam sites.
+          <h2 className="text-heading font-serif my-6">
+            這些網站都自稱「{name}」
+          </h2>
+          <Paragraph>
+            以下是內政部警政署 165 的開放資料所公布，使用「{name}
+            」名義的詐騙網站，以及收到回報的次數。
+          </Paragraph>
           <table>
             <thead>
               <tr>
@@ -44,36 +57,43 @@ export default async function ReportByName({
         </>
       )}
 
-      <h2>Similar entries on 165</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>網域</th>
-            <th>Reported</th>
-          </tr>
-        </thead>
-        <tbody>
-          {ftsHits.map((record) => (
-            <tr key={record.rowid}>
-              <td>
-                <Link href={`/name/${record.nameTokens.join('')}`}>
-                  <Highlighted tokens={record.nameTokens} />
-                </Link>
-              </td>
-              <td>
-                <Link href={`/host/${record.hostTokens.join('')}`}>
-                  <Highlighted tokens={record.hostTokens} />
-                </Link>
-              </td>
-              <td>
-                {record.count} time(s) during {record.startDate} and{' '}
-                {record.endDate}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      {ftsHits.length > 0 && (
+        <>
+          <Paragraph>
+            以下是網站名稱或網址與「{name}」相似的詐騙網站紀錄，供您參考。
+          </Paragraph>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>網域</th>
+                <th>Reported</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ftsHits.map((record) => (
+                <tr key={record.rowid}>
+                  <td>
+                    <Link href={`/name/${record.nameTokens.join('')}`}>
+                      <Highlighted tokens={record.nameTokens} />
+                    </Link>
+                  </td>
+                  <td>
+                    <Link href={`/host/${record.hostTokens.join('')}`}>
+                      <Highlighted tokens={record.hostTokens} />
+                    </Link>
+                  </td>
+                  <td>
+                    {record.count} time(s) during {record.startDate} and{' '}
+                    {record.endDate}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
     </>
   );
 }

--- a/app/name/util.tsx
+++ b/app/name/util.tsx
@@ -31,3 +31,22 @@ export const getRecords = cache(async (name: string) => {
 
   return Promise.all([directHitPromise, searchSimilar(name)]);
 });
+
+/** Get summary text for a site name */
+export function getSummary(name: string, directHits: Record[]) {
+  if (directHits.length === 0) {
+    return `內政部警政署公布的詐騙網站中，目前沒有「${name}」。`;
+  }
+
+  const latest = directHits[0];
+  const countSum = directHits.reduce((sum, { count }) => sum + count, 0);
+
+  return (
+    <>
+      近期詐團{' '}
+      <mark className="highlighter">使用「{latest.name}」名義行騙</mark>。
+      內政部警政署已收到 {countSum} 次民眾檢舉以「{latest.name}」為名的網站，
+      最近 {latest.count} 次落在 {latest.endDate} 那週，請務必小心！
+    </>
+  );
+}

--- a/components/Mitigation.tsx
+++ b/components/Mitigation.tsx
@@ -1,12 +1,12 @@
 export default function Mitigation() {
   return (
     <>
-      <h1>留意二次詐騙</h1>
+      <h2 className="text-heading font-serif my-2">留意二次詐騙</h2>
       <p>
         請不要相信任何聲稱可以幫助您追回被騙資金的人，這些人可能是詐騙集團的一部分。
       </p>
 
-      <h1>請儘速報案</h1>
+      <h2 className="text-heading font-serif my-2">請儘速報案</h2>
       <p>可以從撥打 165 反詐騙中心的電話開始，或者直接到警察局報案。</p>
       <p>報案前請先備妥以下資料，以利警方調查：</p>
       <ul>

--- a/components/contents.tsx
+++ b/components/contents.tsx
@@ -12,10 +12,7 @@ export function Heading({
 }: React.ComponentPropsWithoutRef<'h1'>) {
   return (
     <h1
-      className={twMerge(
-        'text-display font-serif font-normal my-14 -tracking-[.01em]',
-        className
-      )}
+      className={twMerge('text-display font-serif my-14', className)}
       {...props}
     >
       {children}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,8 +17,15 @@ const config: Config = {
         // From local styles in Figma
         body: ['18px', '28px'],
         body2: ['16px', '24px'],
-        heading: ['22px', '28px'],
-        display: ['57px', '64px'],
+        heading: ['22px', { lineHeight: '28px', fontWeight: 900 }],
+        display: [
+          '57px',
+          {
+            lineHeight: '64px',
+            letterSpacing: '-0.01em',
+            fontWeight: 300,
+          },
+        ],
 
         // NextUI token
         medium: '1em',


### PR DESCRIPTION
Implement summary for name detail and adjust site font.

https://detail-refactor.open165.pages.dev/name/%E4%B8%8A%E6%B5%B7%E6%9C%9F%E8%B2%A8%E4%BA%A4%E6%98%93%E6%89%80
![圖片](https://github.com/user-attachments/assets/e0fc6e71-37bb-4493-bf78-9abac4e7d4a5)
![圖片](https://github.com/user-attachments/assets/b755a12f-b62b-4ea3-933f-83ebef3984ac)
